### PR TITLE
Kill Tracee incase of a leak

### DIFF
--- a/main.go
+++ b/main.go
@@ -379,11 +379,9 @@ func KillApp(program *exec.Cmd, iPPort string) {
 
 // KillTracee kills the specific tracee process causing the leak.
 func KillTracee(traceePID int) error {
-	fmt.Println("123 running")
 	if err := syscall.Kill(traceePID, syscall.SIGKILL); err != nil {
 		return fmt.Errorf("failed to kill tracee PID %d: %w", traceePID, err)
 	}
-	fmt.Println("000000 done ")
 	log.Infof("Killed tracee PID: %d due to a proxy leak.", traceePID)
 	return nil
 }


### PR DESCRIPTION
During testing, killing the tracee causes a panic ([here](https://github.com/namecoin/sockstrace/blob/master/main.go#L157)) because the system tried to trace the terminated process. (Not sure how we should handle this, maybe if the flag is set we can skip the error)
Error : `panic: ptrace(PTRACE_SYSCALL): on pid 26224: no such process`